### PR TITLE
Improve js to redirect buyer to stripe checkout page

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "13.1.0",
+  "version": "13.1.1",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
This PR attempt to address #9 

### Changes
- I migrated away from the stripe js library because `stripe.redirectToCheckout` [is deprecated](https://docs.stripe.com/js/deprecated/redirect_to_checkout). The new js will redirect buyer using the good old `window.location.href`.
- I also set the form action to the payment provider's error url instead of continue url. With that change, if the form is somehow submitted, god forbids that, the buyer will be redirected to the error url instead of the continue (success) url like the current version.